### PR TITLE
log to stdout not file

### DIFF
--- a/pywps.cfg
+++ b/pywps.cfg
@@ -39,7 +39,6 @@ mode=default
 
 [logging]
 level=INFO
-file=logs/pywps.log
 database=sqlite:///logs/pywps-logs.sqlite3
 
 [grass]

--- a/wps.py
+++ b/wps.py
@@ -31,6 +31,14 @@ from pywps import Service
 from processes.fcdrill import FcDrill
 from processes.wofsdrill import WofsDrill
 
+import logging
+
+logger = logging.getLogger('PYWPS')
+handler = logging.StreamHandler()
+format = '%(asctime)s] [%(levelname)s] file=%(pathname)s line=%(lineno)s module=%(module)s function=%(funcName)s %(message)s'
+handler.setFormatter(logging.Formatter(format))
+logger.addHandler(handler)
+
 
 if os.environ.get("SENTRY_KEY") and os.environ.get("SENTRY_PROJECT"):
    sentry_sdk.init(


### PR DESCRIPTION
- k8s has no direct access to `pywps.log` inside the pod
- so log to `stdout` that can be captured by k8s

- [X] Closes issue #25