### PR TITLE
Fix issue #23

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ outputurl=https://wps.services.dea.ga.gov.au/outputs/
 ## Changing Processes in WPS
 The processes which are available to users of the WPS are enumerated in the `DEA_WPS_config.yaml` file.
 
+### Resource allocation
+The environment variable `DATACUBE_WPS_NUM_WORKERS` sets the number of workers (defaults to 4).
+
 # WPS development testing from Web
 ## Workflow testing - from terria to wps service
 1. Generate a specific terria catalog for wps terria testing http://terria-catalog-tool.dev.dea.ga.gov.au/wps

--- a/datacube_wps/processes/fcdrill.py
+++ b/datacube_wps/processes/fcdrill.py
@@ -1,11 +1,8 @@
 from timeit import default_timer
-import multiprocessing
 
 import altair
 import xarray
 import numpy as np
-
-from dask.distributed import Client
 
 from datacube.storage.masking import make_mask
 
@@ -82,10 +79,9 @@ class FCDrill(PolygonDrill):
             'Unobservable': (not_pixels / total_valid)['BS'] * 100
         })
 
-        print('calling dask with', multiprocessing.cpu_count(), 'processes')
+        print('dask compute')
         dask_time = default_timer()
-        with Client(threads_per_worker=1):
-            new_ds = new_ds.compute()
+        new_ds = new_ds.compute()
         print('dask took', default_timer() - dask_time, 'seconds')
         print(new_ds)
 

--- a/datacube_wps/processes/mangrovedrill.py
+++ b/datacube_wps/processes/mangrovedrill.py
@@ -1,6 +1,3 @@
-import multiprocessing
-
-from dask.distributed import Client
 import xarray
 import altair
 from . import PolygonDrill, log_call, chart_dimensions
@@ -10,11 +7,7 @@ class MangroveDrill(PolygonDrill):
 
     @log_call
     def process_data(self, data):
-        print('calling dask with', multiprocessing.cpu_count(), 'processes')
-        with Client(threads_per_worker=1):
-            data = data.compute()
-        print('data loaded')
-        print(data)
+        data = data.compute()
 
         # TODO raise ProcessError('query returned no data') when appropriate
         woodland = data.where(data == 1).count(['x', 'y'])


### PR DESCRIPTION
- Use environment variable `DATACUBE_WPS_NUM_WORKERS` to set the number of workers (threads for pixel-drill, processes for polygon-drill)

- [X] Closes issue #23 