### PR TITLE
removes the codecov token

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,5 @@ jobs:
       - name: Upload coverage
         uses: codecov/codecov-action@v1
         with:
-          token: ${{ secrets.CodeCovToken }}
           file: ./artifacts/*.xml
           fail_ci_if_error: false


### PR DESCRIPTION
A CodeCov token not required for public repositories uploading from Travis, CircleCI, AppVeyor, Azure Pipelines or GitHub Actions 

The existing CodeCov token has been regenerated