### PR TITLE
#114 Initial pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+-   repo: https://github.com/PyCQA/isort
+    rev: 5.9.2
+    hooks:
+    -   id: isort
+-   repo: https://github.com/PyCQA/flake8
+    rev: 3.9.2
+    hooks:
+    -   id: flake8
+-   repo: https://github.com/PyCQA/bandit
+    rev: 1.7.0
+    hooks:
+    -   id: bandit
+-   repo: https://github.com/PyCQA/pylint
+    rev: v2.9.3
+    hooks:
+      - id: pylint

--- a/lint-code.sh
+++ b/lint-code.sh
@@ -2,6 +2,8 @@ set -eu
 set -x
 
 isort --check --diff .
+# Consider replacing pycodestyle with autopep8 or flake8
+# See discussions here : https://github.com/pre-commit/pre-commit-hooks/issues/319
 pycodestyle --max-line-length=120 datacube_wps tests
 pylint -j 2 --reports no datacube_wps --disable=C,R,redefined-builtin,fixme,arguments-differ
 bandit -s B101,B104 -r .


### PR DESCRIPTION
Git pre-commit hooks ease application of PyCQA practices before code is pushed to a remote and fails CI tests. This is a first cut very heavy handed pre-commit setup. For developers wishing to use it perform the following steps.

```
pip install pre-commit
pre-commit install
```

From then on pre-commit will trigger linter checks before code is committed to git locally.