### PR TITLE
break lint-code.sh into parallel github lint jobs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -58,3 +58,29 @@ jobs:
           targets: |  # or a single string "."
             test_package
           options: "-r -s B101,B104"
+
+  pylint:
+    runs-on: ubuntu-latest
+    # strategy:
+    #   matrix:
+    #     python-version: [3.8]
+    name: Pylint
+    steps:
+      - name: checkout git
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      # - name: Install Airflow and Lint
+      #   uses: s-weigand/setup-conda@v1
+      #   with:
+      #     update-conda: true
+      #     python-version: ${{ matrix.python-version }}
+      #     conda-channels: anaconda, conda-forge
+      # - name: Check conda version
+      #   run: conda --version
+      # - name: Check python
+      #   run: which python
+      - name: Install airflow and run pylint
+        run: |
+          pip install pylint
+          pylint -j 2 --reports no datacube_wps --disable=C,R,redefined-builtin,fixme,arguments-differ

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,10 +50,11 @@ jobs:
 
   bandit:
     runs-on: ubuntu-latest
-    - uses: actions/checkout@v2
-    - name: Run bandit
-      uses: tj-actions/bandit@v5
-      with:
-        targets: |  # or a single string "."
-          test_package
-        options: "-r -s B101,B104"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run bandit
+        uses: tj-actions/bandit@v5
+        with:
+          targets: |  # or a single string "."
+            test_package
+          options: "-r -s B101,B104"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,3 +30,30 @@ jobs:
       - name: Lint WPS image
         run: |
           docker run ${ORG}/${IMAGE}:latest /bin/sh -c "./lint-code.sh"
+
+  isort:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - run: python -m pip install isort
+      - name: isort
+        uses: liskin/gh-problem-matcher-wrap@v1
+        with:
+          linters: isort
+          run: |
+            isort --check --diff .
+
+  bandit:
+    runs-on: ubuntu-latest
+    - uses: actions/checkout@v2
+    - name: Run bandit
+      uses: tj-actions/bandit@v5
+      with:
+        targets: |  # or a single string "."
+          test_package
+        options: "-r -s B101,B104"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -82,5 +82,6 @@ jobs:
       #   run: which python
       - name: Install airflow and run pylint
         run: |
+          pip install -r requirement.txt
           pip install pylint
           pylint -j 2 --reports no datacube_wps --disable=C,R,redefined-builtin,fixme,arguments-differ

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -82,6 +82,6 @@ jobs:
       #   run: which python
       - name: Install airflow and run pylint
         run: |
-          pip install -r requirement.txt
+          pip install -r requirements.txt
           pip install pylint
           pylint -j 2 --reports no datacube_wps --disable=C,R,redefined-builtin,fixme,arguments-differ

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,21 +15,21 @@ env:
   IMAGE: wps
 
 jobs:
-  quality-check:
-    runs-on: ubuntu-latest
+  # quality-check:
+  #   runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+  #   steps:
+  #     - name: Checkout Code
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
 
-      - name: Build WPS image
-        run: |
-          docker build --tag ${ORG}/${IMAGE}:latest .
-      - name: Lint WPS image
-        run: |
-          docker run ${ORG}/${IMAGE}:latest /bin/sh -c "./lint-code.sh"
+  #     - name: Build WPS image
+  #       run: |
+  #         docker build --tag ${ORG}/${IMAGE}:latest .
+  #     - name: Lint WPS image
+  #       run: |
+  #         docker run ${ORG}/${IMAGE}:latest /bin/sh -c "./lint-code.sh"
 
   isort:
     runs-on: ubuntu-latest
@@ -61,25 +61,12 @@ jobs:
 
   pylint:
     runs-on: ubuntu-latest
-    # strategy:
-    #   matrix:
-    #     python-version: [3.8]
     name: Pylint
     steps:
       - name: checkout git
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      # - name: Install Airflow and Lint
-      #   uses: s-weigand/setup-conda@v1
-      #   with:
-      #     update-conda: true
-      #     python-version: ${{ matrix.python-version }}
-      #     conda-channels: anaconda, conda-forge
-      # - name: Check conda version
-      #   run: conda --version
-      # - name: Check python
-      #   run: which python
       - name: Install airflow and run pylint
         run: |
           pip install -r requirements.txt

--- a/datacube_wps/impl.py
+++ b/datacube_wps/impl.py
@@ -17,7 +17,7 @@ def create_process(process, input, **settings):
 
 
 def read_process_catalog(catalog_filename):
-    with open(catalog_filename) as fl:
+    with open(catalog_filename, encoding='utf-8') as fl:
         config = yaml.safe_load(fl)
 
     return [create_process(**settings) for settings in config['processes']]

--- a/lint-code.sh
+++ b/lint-code.sh
@@ -1,11 +1,10 @@
 set -eu
 set -x
 
-isort --check --diff .
 # Consider replacing pycodestyle with autopep8 or flake8
 # See discussions here : https://github.com/pre-commit/pre-commit-hooks/issues/319
 pycodestyle --max-line-length=120 datacube_wps tests
 pylint -j 2 --reports no datacube_wps --disable=C,R,redefined-builtin,fixme,arguments-differ
-bandit -s B101,B104 -r .
+# bandit -s B101,B104 -r .
 
 set +x

--- a/lint-code.sh
+++ b/lint-code.sh
@@ -4,7 +4,7 @@ set -x
 # Consider replacing pycodestyle with autopep8 or flake8
 # See discussions here : https://github.com/pre-commit/pre-commit-hooks/issues/319
 pycodestyle --max-line-length=120 datacube_wps tests
-pylint -j 2 --reports no datacube_wps --disable=C,R,redefined-builtin,fixme,arguments-differ
+#pylint -j 2 --reports no datacube_wps --disable=C,R,redefined-builtin,fixme,arguments-differ
 # bandit -s B101,B104 -r .
 
 set +x

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,10 +9,9 @@ python-dateutil
 sentry_sdk[flask]
 blinker
 prometheus-flask-exporter
-bandit
+# bandit
 pycodestyle
 pylint
-isort
 pytest
 pytest-cov
 pytest-flask

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,9 +9,8 @@ python-dateutil
 sentry_sdk[flask]
 blinker
 prometheus-flask-exporter
-# bandit
 pycodestyle
-pylint
+# pylint
 pytest
 pytest-cov
 pytest-flask


### PR DESCRIPTION
- remove library `isort`, `pylint` and `bandit` from requirements.txt
- setup isort as a parallel github action job in lint
- setup bandit as a parallel github action job in lint
- setup pylint as a parallel github action job in lint
