### PR TITLE
improve docker-compose and fix test ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,6 @@ on:
 env:
   ORG: opendatacube
   IMAGE: wps
-  METADATA_CATALOG: https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/master/workspaces/sandbox-metadata.yaml
-  PRODUCT_CATALOG: https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/master/workspaces/sandbox-products.csv
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,11 +26,11 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
 
-      - name: Pre-pull layers
-        run: docker-compose pull
+      # - name: Pre-pull layers
+      #   run: docker-compose pull
 
-      - name: Build WPS image
-        run: docker-compose build
+      # - name: Build WPS image
+      #   run: docker-compose build
 
       - name: Bring up containers
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,10 +3,14 @@ name: Tests
 
 on:
   pull_request:
+    branches:
+        - 'master'
     paths:
       - '**'
 
   push:
+    branches:
+      - 'master'
     paths:
       - '**'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,11 +26,11 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
 
-      # - name: Pre-pull layers
-      #   run: docker-compose pull
+      - name: Pre-pull layers
+        run: docker-compose pull
 
-      # - name: Build WPS image
-      #   run: docker-compose build
+      - name: Build WPS image
+        run: docker-compose build
 
       - name: Bring up containers
         run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,9 @@ services:
       - GDAL_HTTP_MAX_RETRY=10
       - GDAL_HTTP_RETRY_DELAY=1
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
+
     ports:
       - "8000:8000"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,8 @@ services:
 
   # Start docker container for datacube-wps
   wps:
-    image: opendatacube/wps:latest
+    # image: opendatacube/wps:latest # for testing
+    build: .
     environment:
       - DB_HOSTNAME=postgres
       - DB_USERNAME=postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     environment:
       POSTGRES_PASSWORD: opendatacubepassword
     healthcheck:
-      test: ["CMD", "pg_isready", "-U", "airflow"]
+      test: ["CMD", "pg_isready", "-U", "postgres"]
       interval: 5s
       retries: 5
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,17 +31,3 @@ services:
       - "8000:8000"
     volumes:
       - ./artifacts:/mnt/artifacts
-
-  # start indexer container
-  index:
-     image: opendatacube/datacube-index:0.0.13
-     environment:
-        - DB_HOSTNAME=postgres
-        - DB_USERNAME=postgres
-        - DB_PASSWORD=opendatacubepassword
-        - DB_DATABASE=postgres
-        - DB_PORT=5432
-        - AWS_DEFAULT_REGION=ap-southeast-2
-     depends_on:
-        - postgres
-     entrypoint: bash -c 'sleep infinity'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   postgres:
     image: postgres:11.5-alpine
     ports:
-      - "127.0.0.1:5432:5432"
+      - "127.0.0.1:5431:5432"
     environment:
       POSTGRES_PASSWORD: opendatacubepassword
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   postgres:
     image: postgres:11.5-alpine
     ports:
-      - "127.0.0.1:5431:5432"
+      - "127.0.0.1:5432:5432"
     environment:
       POSTGRES_PASSWORD: opendatacubepassword
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,12 @@ services:
       - "127.0.0.1:5431:5432"
     environment:
       POSTGRES_PASSWORD: opendatacubepassword
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "airflow"]
+      interval: 5s
+      retries: 5
     restart: always
+
 
   # Start docker container for datacube-wps
   wps:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
 
   # Start docker container for datacube-wps
   wps:
-    build: .
+    image: opendatacube/wps:latest
     environment:
       - DB_HOSTNAME=postgres
       - DB_USERNAME=postgres

--- a/setup-db.sh
+++ b/setup-db.sh
@@ -43,14 +43,11 @@ if [ ! -f dump.sql ]; then
    's3://dea-public-data/mangrove_cover/v2.0.2/x_13/y_-17/2000/*.yaml'
    's3://dea-public-data/mangrove_cover/v2.0.2/x_13/y_-16/2000/*.yaml'
 EOF
-   ls # check dump.sql
    docker-compose exec -T -u postgres postgres pg_dump > dump.sql
 
 else
 
    echo Reusing cache..
-   ls
-   docker ps
    docker-compose exec -T -u postgres postgres psql < dump.sql
 
 fi

--- a/setup-db.sh
+++ b/setup-db.sh
@@ -49,7 +49,8 @@ EOF
 else
 
    echo Reusing cache..
-
+   ls
+   docker ps
    docker-compose exec -T -u postgres postgres psql < dump.sql
 
 fi

--- a/setup-db.sh
+++ b/setup-db.sh
@@ -19,12 +19,12 @@ if [ ! -f dump.sql ]; then
 
    stac () { curl -s "$index/stac/search?collections=$1&datetime=$2T00:00:00Z/$3T00:00:00Z&bbox=$4&limit=500" |
 	     jq '.features[].links[] | select(.rel == "odc_yaml") | .href'; }
-   
+
    {
-       stac ga_ls_wo_3 2000-01-01 2001-01-01 "137.01,-28.76,137.02,-28.75" 
-       
+       stac ga_ls_wo_3 2000-01-01 2001-01-01 "137.01,-28.76,137.02,-28.75"
+
        stac "ga_ls8c_ard_3,ga_ls7e_ard_3,ga_ls_fc_3,ga_ls_wo_3" 2019-03-01 2019-08-01 "146.65,-36.16,147.29,-35.66"
-       
+
        #stac mangrove_cover 2000-01-01 2006-01-01 "143.98,-14.69,144.27,-14.39"
 
    } | xargs -L1 $cmd -v dataset add --confirm-ignore-lineage
@@ -43,12 +43,12 @@ if [ ! -f dump.sql ]; then
    's3://dea-public-data/mangrove_cover/v2.0.2/x_13/y_-17/2000/*.yaml'
    's3://dea-public-data/mangrove_cover/v2.0.2/x_13/y_-16/2000/*.yaml'
 EOF
-
+   ls # check dump.sql
    docker-compose exec -T -u postgres postgres pg_dump > dump.sql
 
 else
 
-   echo Reusing cache..	
+   echo Reusing cache..
 
    docker-compose exec -T -u postgres postgres psql < dump.sql
 


### PR DESCRIPTION
- remove `indexer` service from `docker-compose.yaml`
- add healthcheck to `postgres` service in `docker-compose.yaml`
- remove legacy `env` setting from `test` ci
- improve `wps` `depends_on` for `postgres readiness`
- remove trailing whitespace from `db-setup.sh`
- pin `test` ci to only run again `master` branch